### PR TITLE
Fix duplicate slug

### DIFF
--- a/src/main/java/com/backendapp/cms/blogging/converter/PostRequestConverter.java
+++ b/src/main/java/com/backendapp/cms/blogging/converter/PostRequestConverter.java
@@ -10,7 +10,6 @@ import org.mapstruct.ReportingPolicy;
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE, uses = PostRequestMapper.class)
 public interface PostRequestConverter {
 
-    @Mapping(source = "slug", target = "slug", qualifiedByName = "mapFromStringToOptionalString")
     @Mapping(source = "excerpt", target = "excerpt", qualifiedByName = "mapFromStringToOptionalString")
     @Mapping(source = "featuredImageUrl", target = "featuredImageUrl", qualifiedByName = "mapFromStringToOptionalString")
     @Mapping(source = "status", target = "status", qualifiedByName = "mapFromStatusEnumToStatusEnum")

--- a/src/main/java/com/backendapp/cms/blogging/dto/CategoryRequestDto.java
+++ b/src/main/java/com/backendapp/cms/blogging/dto/CategoryRequestDto.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 public class CategoryRequestDto {
     @NotBlank(message = "Nama kategori tidak boleh kosong")
     String name;
-    Optional<String> slug = Optional.empty();
     Optional<String> description = Optional.empty();
     Optional<List<Long>> posts = Optional.empty();
 }

--- a/src/main/java/com/backendapp/cms/blogging/dto/PostRequestDto.java
+++ b/src/main/java/com/backendapp/cms/blogging/dto/PostRequestDto.java
@@ -20,7 +20,6 @@ import java.util.Set;
 public class PostRequestDto {
     @NotBlank(message = "Judul tidak boleh kosong")
     String title;
-    Optional<String> slug = Optional.empty();
     @NotBlank(message = "Content tidak boleh kosong")
     String content;
     Optional<String> excerpt = Optional.empty();
@@ -35,7 +34,6 @@ public class PostRequestDto {
         if (o == null || getClass() != o.getClass()) return false;
         PostRequestDto that = (PostRequestDto) o;
         return Objects.equals(title, that.title) &&
-                Objects.equals(slug, that.slug) &&
                 Objects.equals(content, that.content) &&
                 Objects.equals(excerpt, that.excerpt) &&
                 Objects.equals(featuredImageUrl, that.featuredImageUrl) &&
@@ -45,7 +43,7 @@ public class PostRequestDto {
 
     @Override
     public int hashCode() {
-        return Objects.hash(title, slug, content, excerpt, featuredImageUrl, status, categories);
+        return Objects.hash(title, content, excerpt, featuredImageUrl, status, categories);
     }
 }
 

--- a/src/main/java/com/backendapp/cms/blogging/endpoint/BloggingEndpoint.java
+++ b/src/main/java/com/backendapp/cms/blogging/endpoint/BloggingEndpoint.java
@@ -33,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 // TODO get all categories
 // TODO check all transaction in services

--- a/src/main/java/com/backendapp/cms/blogging/endpoint/BloggingEndpoint.java
+++ b/src/main/java/com/backendapp/cms/blogging/endpoint/BloggingEndpoint.java
@@ -2,17 +2,17 @@ package com.backendapp.cms.blogging.endpoint;
 
 import com.backendapp.cms.blogging.converter.CategoryRequestConverter;
 import com.backendapp.cms.blogging.converter.CategoryResponseConverter;
+import com.backendapp.cms.blogging.converter.PostRequestConverter;
 import com.backendapp.cms.blogging.converter.PostResponseConverter;
 import com.backendapp.cms.blogging.dto.CategoryRequestDto;
+import com.backendapp.cms.blogging.dto.PostRequestDto;
 import com.backendapp.cms.blogging.entity.CategoryEntity;
 import com.backendapp.cms.blogging.entity.PostEntity;
 import com.backendapp.cms.blogging.exception.NoCategoryException;
 import com.backendapp.cms.blogging.exception.NoPostsException;
 import com.backendapp.cms.blogging.repository.CategoryCrudRepository;
 import com.backendapp.cms.blogging.repository.PostCrudRepository;
-import com.backendapp.cms.blogging.service.CreateCategoryOperationPerformer;
-import com.backendapp.cms.blogging.service.GetAllArticleOperationPerformer;
-import com.backendapp.cms.blogging.service.PostArticleOperationPerformer;
+import com.backendapp.cms.blogging.service.*;
 import com.backendapp.cms.common.enums.Deleted;
 import com.backendapp.cms.common.enums.SortBy;
 import com.backendapp.cms.common.enums.SortOrder;
@@ -52,6 +52,9 @@ public class BloggingEndpoint implements BloggingControllerApi {
     private final CategoryCrudRepository categoryCrudRepository;
     private final GetAllArticleOperationPerformer getAllArticleOperationPerformer;
     private final PaginationConverter paginationConverter;
+    private final PostRequestConverter postRequestConverter;
+    private final UpdateSingleCategoryOperationPerformer updateSingleCategoryOperationPerformer;
+    private final UpdateSingleArticleOperationPerformer updateSingleArticleOperationPerformer;
 
     @Override
     @PreAuthorize("isAuthenticated()")
@@ -219,14 +222,36 @@ public class BloggingEndpoint implements BloggingControllerApi {
 
     @Override
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<GetSingleArticle200Response> editSingleArticleCategories(Long id, List<PostRequest> postRequest) {
-        return BloggingControllerApi.super.editSingleArticleCategories(id, postRequest);
+    public ResponseEntity<EditSingleCategory200Response> editSingleCategory(Long id, CategoryRequest categoryRequest) {
+        UserEntity user = (UserEntity) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        CategoryRequestDto category = categoryRequestConverter.fromCategoryRequestToCategoryRequestDto(categoryRequest);
+
+        CategoryEntity updateCategory = updateSingleCategoryOperationPerformer.update(id, category, user);
+        CategoriesSimpleDTO data = categoryResponseConverter.fromCategoriesEntityToCategorySimpleDto(updateCategory);
+
+        EditSingleCategory200Response response = new EditSingleCategory200Response();
+        response.setSuccess(true);
+        response.setMessage("Berhasil mengedit kategori");
+        response.setData(data);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<PostArticle200Response> updateSingleArticle(Long id, PostRequest postRequest) {
-        return BloggingControllerApi.super.updateSingleArticle(id, postRequest);
+        UserEntity user = (UserEntity) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        PostRequestDto article = postRequestConverter.fromPostRequestToPostRequestDto(postRequest);
+
+        PostEntity updatedArticle = updateSingleArticleOperationPerformer.update(id, article, user);
+        PostSimpleResponse data = postResponseConverter.fromPostEntityToPostSimpleResponse(updatedArticle);
+
+        PostArticle200Response response = new PostArticle200Response();
+        response.setSuccess(true);
+        response.setMessage("Berhasil mengedit data artikel");
+        response.setData(data);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override

--- a/src/main/java/com/backendapp/cms/blogging/entity/CategoryEntity.java
+++ b/src/main/java/com/backendapp/cms/blogging/entity/CategoryEntity.java
@@ -4,12 +4,13 @@ import com.backendapp.cms.users.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
-import org.hibernate.annotations.Where;
+import org.hibernate.proxy.HibernateProxy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.Set;
 
 
@@ -36,6 +37,7 @@ public class CategoryEntity {
 
     @ManyToMany(mappedBy = "categories", fetch = FetchType.LAZY, cascade = {CascadeType.DETACH, CascadeType.MERGE, CascadeType.REFRESH})
     @SQLRestriction("deleted_at IS NULL")
+    @ToString.Exclude
     private Set<PostEntity> posts;
 
     @Column(name = "slug", unique = true, nullable = false)
@@ -55,4 +57,19 @@ public class CategoryEntity {
     @Column(name = "deleted_at", nullable = true)
     private LocalDateTime deletedAt;
 
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        CategoryEntity category = (CategoryEntity) o;
+        return getId() != null && Objects.equals(getId(), category.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
 }

--- a/src/main/java/com/backendapp/cms/blogging/helper/CategoryGenerator.java
+++ b/src/main/java/com/backendapp/cms/blogging/helper/CategoryGenerator.java
@@ -45,7 +45,8 @@ public class CategoryGenerator {
     }
 
     public CategoryEntity checkOrCreate(String categoryNames, UserEntity user) {
-        Optional<CategoryEntity> category = categoryCrudRepository.findByNameAndUser(categoryNames, user);
+        String categoryName = categorySanitizer.toPlainText(categoryNames);
+        Optional<CategoryEntity> category = categoryCrudRepository.findByNameAndUser(categoryName, user);
         if (category.isEmpty()) {
             return generateCategoryByName(categoryNames, user);
         }

--- a/src/main/java/com/backendapp/cms/blogging/helper/PostGenerator.java
+++ b/src/main/java/com/backendapp/cms/blogging/helper/PostGenerator.java
@@ -27,22 +27,7 @@ public class PostGenerator {
      * @param title the post title
      * @return unique slug
      */
-    public String generateSlug(Optional<String> slug, String title) {
-        if (slug.isPresent()) {
-            String presentSlug = plainText.sanitize(slug.get()).toLowerCase();
-            String regexPattern = "^" + escapeRegex(presentSlug) + "(-[0-9]+)?$";
-            List<PostEntity> findPostLikeSlug = postCrudRepository.findSlugPatternNative(presentSlug, regexPattern);
-            if (findPostLikeSlug.isEmpty()) {
-                return slugFormat(presentSlug);
-            }
-
-            log.warn("slug exists in database");
-            int existsSlugs = findPostLikeSlug.size();
-
-
-            return slugFormat(presentSlug + "-" + (existsSlugs + 1));
-        }
-
+    public String generateSlug(String title) {
         if (title != null) {
             String presentTitle = plainText.sanitize(title).toLowerCase();
             String regexPattern = "^" + escapeRegex(presentTitle) + "(-[0-9]+)?$";
@@ -52,9 +37,7 @@ public class PostGenerator {
             }
 
             log.warn("slug exists in database");
-            int existsSlugs = findPostLikeSlug.size();
-
-            return slugFormat(presentTitle + "-" + (existsSlugs + 1));
+            return slugFormat(presentTitle + "-" + System.currentTimeMillis());
         }
 
         return UUID.randomUUID().toString();

--- a/src/main/java/com/backendapp/cms/blogging/helper/PostSanitizer.java
+++ b/src/main/java/com/backendapp/cms/blogging/helper/PostSanitizer.java
@@ -55,7 +55,6 @@ public class PostSanitizer {
 
         return PostRequestDto.builder()
                 .title(sanitizedTitle)
-                .slug(unSanitizedPostRequest.getSlug())
                 .content(sanitizedContent)
                 .excerpt(sanitizedExcerpt)
                 .featuredImageUrl(sanitizedImageUrl)
@@ -83,7 +82,6 @@ public class PostSanitizer {
 
         return PostRequestDto.builder()
                 .title(convertedTitle)
-                .slug(unConvertedPostRequest.getSlug())
                 .content(convertedContent)
                 .excerpt(Optional.ofNullable(convertedExcerpt))
                 .featuredImageUrl(unConvertedPostRequest.getFeaturedImageUrl())

--- a/src/main/java/com/backendapp/cms/blogging/repository/CategoryCrudRepository.java
+++ b/src/main/java/com/backendapp/cms/blogging/repository/CategoryCrudRepository.java
@@ -3,6 +3,7 @@ package com.backendapp.cms.blogging.repository;
 import com.backendapp.cms.blogging.entity.CategoryEntity;
 import com.backendapp.cms.openapi.dto.CategoriesSimpleDTO;
 import com.backendapp.cms.users.entity.UserEntity;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -20,4 +21,6 @@ public interface CategoryCrudRepository extends JpaRepository<CategoryEntity, Lo
     Optional<List<CategoryEntity>> findAllByUserAndDeletedAtIsNull(UserEntity user);
 
     Optional<CategoryEntity> findByIdAndUserAndDeletedAtIsNull(Long id, UserEntity user);
+
+    boolean existsByNameAndUser(@NotBlank(message = "Nama kategori tidak boleh kosong") String name, UserEntity user);
 }

--- a/src/main/java/com/backendapp/cms/blogging/repository/PostCrudRepository.java
+++ b/src/main/java/com/backendapp/cms/blogging/repository/PostCrudRepository.java
@@ -4,15 +4,16 @@ import com.backendapp.cms.blogging.entity.PostEntity;
 import com.backendapp.cms.users.entity.UserEntity;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface PostCrudRepository extends JpaRepository<PostEntity, Long> {
@@ -33,4 +34,6 @@ public interface PostCrudRepository extends JpaRepository<PostEntity, Long> {
 
 
     Page<PostEntity> findAll(Specification<PostEntity> specification, Pageable pageable);
+
+    Set<PostEntity> findAllByIdInAndUser(Collection<Long> id, UserEntity user);
 }

--- a/src/main/java/com/backendapp/cms/blogging/service/CreateCategoryOperationPerformer.java
+++ b/src/main/java/com/backendapp/cms/blogging/service/CreateCategoryOperationPerformer.java
@@ -21,16 +21,14 @@ public class CreateCategoryOperationPerformer {
     private final CategoryCrudRepository categoryCrudRepository;
     private final PostCrudRepository postCrudRepository;
     private final CategoryGenerator categoryGenerator;
-    private final CategorySanitizer categorySanitizer;
 
     @Transactional
     public CategoryEntity createCategory(@Valid CategoryRequestDto category, UserEntity user) {
-        // sanitized
-        String categoryName = categorySanitizer.toPlainText(category.getName());
-
-        CategoryEntity categoryEntity = categoryGenerator.checkOrCreate(categoryName, user);
+        CategoryEntity categoryEntity = categoryGenerator.checkOrCreate(category.getName(), user); // termasuk generate slug
         category.getDescription().ifPresent(categoryEntity::setDescription);
-        category.getPosts().ifPresent(postCrudRepository::findAllById);
+        category.getPosts().ifPresent((listOfPost) -> {
+            categoryEntity.setPosts(postCrudRepository.findAllByIdInAndUser(listOfPost, user));
+        });
 
         return categoryCrudRepository.save(categoryEntity);
     }

--- a/src/main/java/com/backendapp/cms/blogging/service/PostArticleOperationPerformer.java
+++ b/src/main/java/com/backendapp/cms/blogging/service/PostArticleOperationPerformer.java
@@ -65,7 +65,7 @@ public class PostArticleOperationPerformer {
 
         PostEntity article = PostEntity.builder()
                 .title(sanitizedRequest.getTitle())
-                .slug(postGenerator.generateSlug(sanitizedRequest.getSlug(), sanitizedRequest.getTitle()))
+                .slug(postGenerator.generateSlug(sanitizedRequest.getTitle()))
                 .content(sanitizedRequest.getContent())
                 .excerpt(sanitizedRequest.getExcerpt()
                         .orElseGet(() -> {

--- a/src/main/java/com/backendapp/cms/blogging/service/UpdateSingleArticleOperationPerformer.java
+++ b/src/main/java/com/backendapp/cms/blogging/service/UpdateSingleArticleOperationPerformer.java
@@ -6,6 +6,7 @@ import com.backendapp.cms.blogging.entity.PostEntity;
 import com.backendapp.cms.blogging.exception.NoPostsException;
 import com.backendapp.cms.blogging.helper.CategoryGenerator;
 import com.backendapp.cms.blogging.helper.CategorySanitizer;
+import com.backendapp.cms.blogging.helper.PostGenerator;
 import com.backendapp.cms.blogging.helper.PostSanitizer;
 import com.backendapp.cms.blogging.repository.PostCrudRepository;
 import com.backendapp.cms.openapi.dto.CategoriesSimpleDTO;
@@ -31,6 +32,7 @@ public class UpdateSingleArticleOperationPerformer {
     private final Validator validator;
     private final CategorySanitizer categorySanitizer;
     private final CategoryGenerator categoryGenerator;
+    private final PostGenerator postGenerator;
 
     @Transactional
     public PostEntity update(Long id, PostRequestDto article, UserEntity user) {
@@ -58,7 +60,7 @@ public class UpdateSingleArticleOperationPerformer {
         }
 
         post.setTitle(sanitizedArticle.getTitle());
-        sanitizedArticle.getSlug().ifPresent(post::setSlug);
+        post.setSlug(postGenerator.generateSlug(sanitizedArticle.getTitle()));
         post.setContent(sanitizedArticle.getContent());
         sanitizedArticle.getExcerpt().ifPresent(post::setExcerpt);
         sanitizedArticle.getFeaturedImageUrl().ifPresent(post::setFeaturedImageUrl);

--- a/src/main/java/com/backendapp/cms/blogging/service/UpdateSingleArticleOperationPerformer.java
+++ b/src/main/java/com/backendapp/cms/blogging/service/UpdateSingleArticleOperationPerformer.java
@@ -1,0 +1,71 @@
+package com.backendapp.cms.blogging.service;
+
+import com.backendapp.cms.blogging.dto.PostRequestDto;
+import com.backendapp.cms.blogging.entity.CategoryEntity;
+import com.backendapp.cms.blogging.entity.PostEntity;
+import com.backendapp.cms.blogging.exception.NoPostsException;
+import com.backendapp.cms.blogging.helper.CategoryGenerator;
+import com.backendapp.cms.blogging.helper.CategorySanitizer;
+import com.backendapp.cms.blogging.helper.PostSanitizer;
+import com.backendapp.cms.blogging.repository.PostCrudRepository;
+import com.backendapp.cms.openapi.dto.CategoriesSimpleDTO;
+import com.backendapp.cms.users.entity.UserEntity;
+import jakarta.transaction.Transactional;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@AllArgsConstructor
+public class UpdateSingleArticleOperationPerformer {
+
+    private final PostCrudRepository postCrudRepository;
+    private final PostSanitizer postSanitizer;
+    private final Validator validator;
+    private final CategorySanitizer categorySanitizer;
+    private final CategoryGenerator categoryGenerator;
+
+    @Transactional
+    public PostEntity update(Long id, PostRequestDto article, UserEntity user) {
+        PostEntity post = postCrudRepository.findByIdAndUser(id, user).orElseThrow(NoPostsException::new);
+        PostRequestDto sanitizedArticle = postSanitizer.sanitize(article);
+
+        // validate
+        Set<ConstraintViolation<PostRequestDto>> violations = validator.validate(sanitizedArticle);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
+
+        // prepare categories
+        Set<CategoryEntity> categories;
+        if (article.getCategories().isPresent()) {
+            List<String> sanitizedCategories = article.getCategories().get()
+                    .stream()
+                    .map(CategoriesSimpleDTO::getName)
+                    .map(categorySanitizer::toPlainText)
+                    .toList();
+
+            categories = categoryGenerator.findOrCreateByName(sanitizedCategories, user);
+        } else {
+            categories = new HashSet<>();
+        }
+
+        post.setTitle(sanitizedArticle.getTitle());
+        sanitizedArticle.getSlug().ifPresent(post::setSlug);
+        post.setContent(sanitizedArticle.getContent());
+        sanitizedArticle.getExcerpt().ifPresent(post::setExcerpt);
+        sanitizedArticle.getFeaturedImageUrl().ifPresent(post::setFeaturedImageUrl);
+        sanitizedArticle.getStatus().ifPresent(post::setStatus);
+        sanitizedArticle.getCategories().ifPresent((newCategories) -> post.setCategories(categories));
+        post.setUpdatedAt(LocalDateTime.now());
+
+        return postCrudRepository.save(post);
+    }
+}

--- a/src/main/java/com/backendapp/cms/blogging/service/UpdateSingleCategoryOperationPerformer.java
+++ b/src/main/java/com/backendapp/cms/blogging/service/UpdateSingleCategoryOperationPerformer.java
@@ -3,6 +3,7 @@ package com.backendapp.cms.blogging.service;
 import com.backendapp.cms.blogging.dto.CategoryRequestDto;
 import com.backendapp.cms.blogging.entity.CategoryEntity;
 import com.backendapp.cms.blogging.entity.PostEntity;
+import com.backendapp.cms.blogging.exception.CategoryAlreadyExistsException;
 import com.backendapp.cms.blogging.exception.NoCategoryException;
 import com.backendapp.cms.blogging.helper.CategoryGenerator;
 import com.backendapp.cms.blogging.helper.CategorySanitizer;
@@ -10,17 +11,15 @@ import com.backendapp.cms.blogging.repository.CategoryCrudRepository;
 import com.backendapp.cms.blogging.repository.PostCrudRepository;
 import com.backendapp.cms.users.entity.UserEntity;
 import jakarta.transaction.Transactional;
-import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 @Service
 @AllArgsConstructor
+@Slf4j
 public class UpdateSingleCategoryOperationPerformer {
 
     private final CategoryCrudRepository categoryCrudRepository;
@@ -30,21 +29,44 @@ public class UpdateSingleCategoryOperationPerformer {
 
     @Transactional
     public CategoryEntity update(Long categoryId, CategoryRequestDto category, UserEntity user) {
-        CategoryEntity categoryEntity = categoryCrudRepository.findByIdAndUserAndDeletedAtIsNull(categoryId, user).orElseThrow(NoCategoryException::new);
-        CategoryEntity duplicationCheck = categoryGenerator.checkOrCreate(categorySanitizer.toPlainText(category.getName()), user);
+        CategoryEntity categoryEntity = categoryCrudRepository.findByIdAndUserAndDeletedAtIsNull(categoryId, user)
+                .orElseThrow(NoCategoryException::new);
 
+        if (!category.getName().equals(categoryEntity.getName())) {
+            CategoryEntity generatedCategory = categoryGenerator.generateCategoryByName(
+                    categorySanitizer.toPlainText(category.getName()), user);
 
-        categoryEntity.setName(duplicationCheck.getName());
-        categoryEntity.setSlug(duplicationCheck.getSlug());
-        category.getDescription().ifPresent(description -> categoryEntity.setDescription(categorySanitizer.toPlainText(description)));
-        category.getPosts().ifPresent(post -> {
-            Set<PostEntity> posts = postCrudRepository.findAllByIdInAndUser(post, user);
-            HashSet<PostEntity> finalPosts = new HashSet<>(posts);
-            finalPosts.addAll(posts);
-            finalPosts.addAll(categoryEntity.getPosts());
-            categoryEntity.setPosts(finalPosts);
-        });
+            if (categoryCrudRepository.existsByNameAndUser(generatedCategory.getName(), user)) {
+                throw new CategoryAlreadyExistsException();
+            }
 
-        return categoryCrudRepository.save(categoryEntity);
+            categoryEntity.setName(generatedCategory.getName());
+            categoryEntity.setSlug(generatedCategory.getSlug());
+        }
+
+        category.getDescription().ifPresent(description ->
+                categoryEntity.setDescription(categorySanitizer.toPlainText(description)));
+
+        Set<PostEntity> oldPosts = categoryEntity.getPosts();
+        if (oldPosts != null && !oldPosts.isEmpty()) {
+            oldPosts.forEach(post -> {
+                post.getCategories().remove(categoryEntity);
+            });
+            postCrudRepository.saveAll(oldPosts);
+        }
+
+        Set<PostEntity> newPosts = new HashSet<>();
+        if (category.getPosts().isPresent() && !category.getPosts().get().isEmpty()) {
+            newPosts = postCrudRepository.findAllByIdInAndUser(category.getPosts().get(), user);
+            newPosts.forEach(post -> {
+                post.getCategories().add(categoryEntity);
+            });
+            postCrudRepository.saveAll(newPosts);
+        }
+
+        categoryEntity.setPosts(newPosts);
+        CategoryEntity savedCategory = categoryCrudRepository.save(categoryEntity);
+
+        return savedCategory;
     }
 }

--- a/src/main/java/com/backendapp/cms/blogging/service/UpdateSingleCategoryOperationPerformer.java
+++ b/src/main/java/com/backendapp/cms/blogging/service/UpdateSingleCategoryOperationPerformer.java
@@ -1,0 +1,50 @@
+package com.backendapp.cms.blogging.service;
+
+import com.backendapp.cms.blogging.dto.CategoryRequestDto;
+import com.backendapp.cms.blogging.entity.CategoryEntity;
+import com.backendapp.cms.blogging.entity.PostEntity;
+import com.backendapp.cms.blogging.exception.NoCategoryException;
+import com.backendapp.cms.blogging.helper.CategoryGenerator;
+import com.backendapp.cms.blogging.helper.CategorySanitizer;
+import com.backendapp.cms.blogging.repository.CategoryCrudRepository;
+import com.backendapp.cms.blogging.repository.PostCrudRepository;
+import com.backendapp.cms.users.entity.UserEntity;
+import jakarta.transaction.Transactional;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+@AllArgsConstructor
+public class UpdateSingleCategoryOperationPerformer {
+
+    private final CategoryCrudRepository categoryCrudRepository;
+    private final CategorySanitizer categorySanitizer;
+    private final CategoryGenerator categoryGenerator;
+    private final PostCrudRepository postCrudRepository;
+
+    @Transactional
+    public CategoryEntity update(Long categoryId, CategoryRequestDto category, UserEntity user) {
+        CategoryEntity categoryEntity = categoryCrudRepository.findByIdAndUserAndDeletedAtIsNull(categoryId, user).orElseThrow(NoCategoryException::new);
+        CategoryEntity duplicationCheck = categoryGenerator.checkOrCreate(categorySanitizer.toPlainText(category.getName()), user);
+
+
+        categoryEntity.setName(duplicationCheck.getName());
+        categoryEntity.setSlug(duplicationCheck.getSlug());
+        category.getDescription().ifPresent(description -> categoryEntity.setDescription(categorySanitizer.toPlainText(description)));
+        category.getPosts().ifPresent(post -> {
+            Set<PostEntity> posts = postCrudRepository.findAllByIdInAndUser(post, user);
+            HashSet<PostEntity> finalPosts = new HashSet<>(posts);
+            finalPosts.addAll(posts);
+            finalPosts.addAll(categoryEntity.getPosts());
+            categoryEntity.setPosts(finalPosts);
+        });
+
+        return categoryCrudRepository.save(categoryEntity);
+    }
+}

--- a/src/main/resources/api-specs/blogging-openapi.yaml
+++ b/src/main/resources/api-specs/blogging-openapi.yaml
@@ -1238,12 +1238,6 @@ components:
           maxLength: 255
           description: "Judul postingan."
           example: "Cara membuat aplikasi cms dengan springboot"
-        slug:
-          type: string
-          minLength: 1
-          maxLength: 255
-          description: "URL Friendly dari judul."
-          example: "cara-membuat-aplikasi-cms-dengan-springboot"
         content:
           type: string
           minLength: 1
@@ -1287,12 +1281,6 @@ components:
           maxLength: 225
           description: "Nama kategori"
           example: "Teknologi Informasi"
-        slug:
-          type: string
-          minLength: 1
-          maxLength: 225
-          description: "URL friendly nama kategori"
-          example: "teknologi-informasi"
         description:
           type: string
           minLength: 1

--- a/src/test/java/com/backendapp/cms/blogging/contract/CategoryBuilder.java
+++ b/src/test/java/com/backendapp/cms/blogging/contract/CategoryBuilder.java
@@ -164,7 +164,6 @@ public class CategoryBuilder {
     public CategoryRequest buildCategoryRequest() {
         CategoryRequest categoryRequest = new CategoryRequest();
         categoryRequest.setName(this.name);
-        categoryRequest.setSlug(this.slug);
         categoryRequest.setDescription(this.description);
         // untuk nanti kedepannya tambahkan POST
 
@@ -174,7 +173,6 @@ public class CategoryBuilder {
     public CategoryRequestDto buildCategoryRequestDto() {
         CategoryRequestDto categoryRequestDto = new CategoryRequestDto();
         categoryRequestDto.setName(this.name);
-        categoryRequestDto.setSlug(Optional.of(this.slug));
         categoryRequestDto.setDescription(Optional.of(this.description));
         // nanti kedepannya tambahkan POST
 

--- a/src/test/java/com/backendapp/cms/blogging/contract/PostBuilder.java
+++ b/src/test/java/com/backendapp/cms/blogging/contract/PostBuilder.java
@@ -4,14 +4,13 @@ import com.backendapp.cms.blogging.dto.PostRequestDto;
 import com.backendapp.cms.blogging.entity.CategoryEntity;
 import com.backendapp.cms.blogging.entity.PostEntity;
 import com.backendapp.cms.common.enums.Status;
-import com.backendapp.cms.openapi.dto.*;
+import com.backendapp.cms.openapi.dto.CategoryResponseAllOfPosts;
+import com.backendapp.cms.openapi.dto.PostRequest;
+import com.backendapp.cms.openapi.dto.PostResponse;
+import com.backendapp.cms.openapi.dto.PostSimpleResponse;
 import com.backendapp.cms.users.entity.UserEntity;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import org.springframework.lang.Nullable;
 
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.*;
 
@@ -188,7 +187,6 @@ public class PostBuilder {
 
         return PostRequestDto.builder()
                 .title(expectedSanitizedTitle)
-                .slug(Optional.of(expectedSanitizedSlug))
                 .content(expectedSanitizedContent)
                 .excerpt(Optional.of(expectedSanitizedExcerpt))
                 .featuredImageUrl(Optional.of("/default.jpg"))
@@ -218,7 +216,6 @@ public class PostBuilder {
 
         return PostRequestDto.builder()
                 .title(expectedTitle)
-                .slug(Optional.of("post-with-basic-markdown"))
                 .content(expectedHtmlContent)
                 .excerpt(Optional.of(expectedHtmlExcerpt))
                 .featuredImageUrl(Optional.of(this.featuredImageUrl))
@@ -248,7 +245,6 @@ public class PostBuilder {
 
         return PostRequestDto.builder()
                 .title(expectedTitle)
-                .slug(Optional.of("post-with-basic-markdown"))
                 .content(expectedHtmlContent)
                 .excerpt(Optional.of(expectedHtmlExcerpt))
                 .featuredImageUrl(Optional.of(this.featuredImageUrl))
@@ -270,7 +266,6 @@ public class PostBuilder {
 
         return PostRequestDto.builder()
                 .title(expectedTitle)
-                .slug(Optional.ofNullable(this.slug))
                 .content(expectedHtmlContent)
                 .excerpt(Optional.of(expectedHtmlExcerpt))
                 .featuredImageUrl(Optional.ofNullable(this.featuredImageUrl))
@@ -283,7 +278,6 @@ public class PostBuilder {
         return PostRequestDto
                 .builder()
                 .title(this.title)
-                .slug(Optional.of(this.slug))
                 .content(this.content)
                 .excerpt(Optional.of(this.excerpt))
                 .featuredImageUrl(Optional.of(this.featuredImageUrl))
@@ -359,7 +353,6 @@ public class PostBuilder {
     public PostRequest buildPostRequest() {
         PostRequest postRequest = new PostRequest();
         postRequest.setTitle(this.title);
-        postRequest.setSlug(this.slug);
         postRequest.setContent(this.content);
         postRequest.setExcerpt(this.excerpt);
         postRequest.setFeaturedImageUrl(this.featuredImageUrl);


### PR DESCRIPTION
Menghapus kemampuan user untuk memnuat custom slug. sekarang semua slug dibuat secata otomatis. 
slug untuk post dibuat menggunakan judul, jika duplicate akan ditambahkan -nowTimeMilis
slug untuk category dibuat menggunkan name. tidak akan duplicate karena name nya unique dan jika name nya duplikat akan mengembalikan CategoryAlreadyExistException.

Fix issue when user edit post of category, hanya bisa menambah post tidak bisa menghapus post. jika meng-uncheck post maka tidak terjadi apa apa.